### PR TITLE
Jag conduit flex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,7 @@ if (LBANN_HAS_ALUMINUM)
 endif ()
 
 if (LBANN_HAS_CONDUIT)
-  target_link_libraries(lbann PUBLIC ${CONDUIT_LIBRARIES})
+  target_link_libraries(lbann PUBLIC CONDUIT::CONDUIT)
 endif ()
 
 #== FIXME HERE DOWN ==

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -27,6 +27,8 @@
 #ifndef _DATA_READER_JAG_CONDUIT_HPP_
 #define _DATA_READER_JAG_CONDUIT_HPP_
 
+#include "lbann_config.hpp" // may define LBANN_HAS_CONDUIT
+
 #ifdef LBANN_HAS_CONDUIT
 #include "lbann/data_readers/opencv.hpp"
 #include "data_reader.hpp"
@@ -45,12 +47,12 @@ class data_reader_jag_conduit : public generic_data_reader {
   using input_t = double; ///< jag input parameter type
 
   /**
-   * Mode of modeling.
-   * - Inverse: image to input param
-   * - AutoI: image to image
-   * - AutoS: scalar to scalar  
+   * Dependent/indepdendent variable types
+   * - JAG_Image: simulation output images
+   * - JAG_Scalar: simulation output scalars
+   * - JAG_Input: simulation input parameters
    */
-  enum model_mode_t {Inverse, AutoI, AutoS};
+  enum variable_t {JAG_Image, JAG_Scalar, JAG_Input};
 
   data_reader_jag_conduit(bool shuffle = true);
   data_reader_jag_conduit(const data_reader_jag_conduit&) = default;
@@ -62,8 +64,15 @@ class data_reader_jag_conduit : public generic_data_reader {
     return "data_reader_jag_conduit";
   }
 
-  /// Set the modeling mode: Inverse, AutoI, or AutoS
-  void set_model_mode(const model_mode_t mm);
+  /// Choose which data to use for independent variable
+  void set_independent_variable_type(const variable_t independent);
+  /// Choose which data to use for dependent variable
+  void set_dependent_variable_type(const variable_t dependent);
+
+  /// Tell which data to use for independent variable
+  variable_t get_independent_variable_type() const;
+  /// Tell which data to use for dependent variable
+  variable_t get_dependent_variable_type() const;
 
   /// Set the image dimension
   void set_image_dims(const int width, const int height);
@@ -164,8 +173,10 @@ class data_reader_jag_conduit : public generic_data_reader {
   std::vector< std::pair<size_t, const ch_t*> > get_image_ptrs(const size_t i) const;
 
  protected:
-  /// The current mode of modeling
-  model_mode_t m_model_mode;
+  /// independent variable type
+  variable_t m_independent;
+  /// dependent variable type
+  variable_t m_dependent;
 
   /// The linearized size of an image
   size_t m_linearized_image_size;

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -186,9 +186,9 @@ class data_reader_jag_conduit : public generic_data_reader {
   int m_image_width; ///< image width
   int m_image_height; ///< image height
 
-  /// keys to select a set of scalar simulation outputs to use
+  /// Keys to select a set of scalar simulation outputs to use. By default, use all.
   std::vector<std::string> m_scalar_keys;
-  /// keys to select a set of simulation input parameters to use
+  /// Keys to select a set of simulation input parameters to use. By default, use all.
   std::vector<std::string> m_input_keys;
 
   /// Whether data have been loaded

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -51,8 +51,9 @@ class data_reader_jag_conduit : public generic_data_reader {
    * - JAG_Image: simulation output images
    * - JAG_Scalar: simulation output scalars
    * - JAG_Input: simulation input parameters
+   * - Undefined: the default
    */
-  enum variable_t {JAG_Image, JAG_Scalar, JAG_Input};
+  enum variable_t {JAG_Image, JAG_Scalar, JAG_Input, Undefined};
 
   data_reader_jag_conduit(bool shuffle = true);
   data_reader_jag_conduit(const data_reader_jag_conduit&) = default;

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -42,6 +42,9 @@
 #include <set>
 #include <map>
 
+#define _THROW_LBANN_EXCEPTION2_(_CLASS_NAME_,_MSG1_,_MSG2_) \
+        _THROW_LBANN_EXCEPTION_(_CLASS_NAME_, (_MSG1_) << (_MSG2_))
+
 // This macro may be moved to a global scope
 #define _THROW_LBANN_EXCEPTION_(_CLASS_NAME_,_MSG_) { \
   std::stringstream err; \
@@ -58,7 +61,7 @@ namespace lbann {
 
 data_reader_jag_conduit::data_reader_jag_conduit(bool shuffle)
   : generic_data_reader(shuffle),
-    m_independent(JAG_Image), m_dependent(JAG_Input),
+    m_independent(Undefined), m_dependent(Undefined),
     m_linearized_image_size(0u),
     m_num_views(2u),
     m_image_width(0u), m_image_height(0u),
@@ -77,7 +80,8 @@ const conduit::Node& data_reader_jag_conduit::get_conduit_node(const std::string
 
 void data_reader_jag_conduit::set_independent_variable_type(
   const data_reader_jag_conduit::variable_t independent) {
-  if (!(independent == JAG_Image || independent == JAG_Scalar || independent == JAG_Input)) {
+  if (!(independent == JAG_Image || independent == JAG_Scalar ||
+        independent == JAG_Input || independent == Undefined)) {
     _THROW_LBANN_EXCEPTION_(_CN_, "unrecognized independent variable type ");
   }
   m_independent = independent;
@@ -85,7 +89,8 @@ void data_reader_jag_conduit::set_independent_variable_type(
 
 void data_reader_jag_conduit::set_dependent_variable_type(
   const data_reader_jag_conduit::variable_t dependent) {
-  if (!(dependent == JAG_Image || dependent == JAG_Scalar || dependent == JAG_Input)) {
+  if (!(dependent == JAG_Image || dependent == JAG_Scalar ||
+        dependent == JAG_Input || dependent == Undefined)) {
     _THROW_LBANN_EXCEPTION_(_CN_, "unrecognized dependent variable type ");
   }
   m_dependent = dependent;
@@ -342,8 +347,9 @@ int data_reader_jag_conduit::get_linearized_data_size() const {
       return static_cast<int>(get_linearized_scalar_size());
     case JAG_Input:
       return static_cast<int>(get_linearized_input_size());
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "get_linearized_data_size() : unknown variable type");
+    default: { // includes Unefined case
+      _THROW_LBANN_EXCEPTION2_(_CN_, "get_linearized_data_size() : ", \
+                                     "unknown or undefined variable type");
     }
   }
   return 0;
@@ -357,8 +363,9 @@ int data_reader_jag_conduit::get_linearized_response_size() const {
       return static_cast<int>(get_linearized_scalar_size());
     case JAG_Input:
       return static_cast<int>(get_linearized_input_size());
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "get_linearized_response_size() : unknown variable type");
+    default: { // includes Undefined case
+      _THROW_LBANN_EXCEPTION2_(_CN_, "get_linearized_response_size() : ", \
+                                     "unknown or undefined variable type");
     }
   }
   return 0;
@@ -373,8 +380,9 @@ const std::vector<int> data_reader_jag_conduit::get_data_dims() const {
       return {static_cast<int>(get_linearized_scalar_size())};
     case JAG_Input:
       return {static_cast<int>(get_linearized_input_size())};
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "get_data_dims() : unknown variable type");
+    default: { // includes Undefined case
+      _THROW_LBANN_EXCEPTION2_(_CN_, "get_data_dims() : ", \
+                                     "unknown or undefined variable type");
     }
   }
   return {};
@@ -550,8 +558,8 @@ bool data_reader_jag_conduit::fetch_datum(Mat& X, int data_id, int mb_idx, int t
       set_minibatch_item<input_t>(X, mb_idx, inputs.data(), get_linearized_input_size());
       break;
     }
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "fetch_datum() : unknown variable type");
+    default: { // includes Undefined case
+      _THROW_LBANN_EXCEPTION_(_CN_, "fetch_datum() : unknown or undefined variable type");
     }
   }
   return true;
@@ -575,8 +583,8 @@ bool data_reader_jag_conduit::fetch_response(Mat& Y, int data_id, int mb_idx, in
       set_minibatch_item<input_t>(Y, mb_idx, inputs.data(), get_linearized_input_size());
       break;
     }
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "fetch_response() : unknown variable type");
+    default: { // includes Undefined case
+      _THROW_LBANN_EXCEPTION_(_CN_, "fetch_response() : unknown or undefined variable type");
     }
   }
   return true;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -78,6 +78,20 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
       reader_jag->set_normalization_mode(pb_preproc.early_normalization());
       reader = reader_jag;
       set_up_generic_preprocessor = false;
+#ifdef LBANN_HAS_CONDUIT
+    } else if (name == "jag_conduit") {
+      auto* reader_jag = new data_reader_jag_conduit(shuffle);
+      const data_reader_jag_conduit::variable_t independent_type
+             = static_cast<data_reader_jag_conduit::variable_t>(readme.independent());
+      reader_jag->set_independent_variable_type(independent_type);
+      const data_reader_jag_conduit::variable_t dependent_type
+             = static_cast<data_reader_jag_conduit::variable_t>(readme.dependent());
+      reader_jag->set_dependent_variable_type(dependent_type);
+      const lbann_data::ImagePreprocessor& pb_preproc = readme.image_preprocessor();
+      reader_jag->set_image_dims(pb_preproc.raw_width(), pb_preproc.raw_height());
+      reader = reader_jag;
+      set_up_generic_preprocessor = false;
+#endif // LBANN_HAS_CONDUIT
     } else if (name == "nci") {
       reader = new data_reader_nci(shuffle);
     } else if (name == "csv") {


### PR DESCRIPTION
Similar to the earlier PR (jag_flex) with jag reader which was to remove the restriction on selecting data sources,
This PR also applies such changes to the other version of new jag reader for conduit packed hdf5 file.