### PR TITLE
Partition jag conduit

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -154,6 +154,10 @@ class lbann_comm {
   inline Grid& get_model_grid() {
     return *grid;
   }
+  /** Return a read-only grid to use for this model. */
+  inline const Grid& get_model_grid() const {
+    return *grid;
+  }
   /** Return the total number of models. */
   inline int get_num_models() const {
     return num_models;

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -253,6 +253,18 @@ class data_reader_jag_conduit : public generic_data_reader {
 #ifndef _JAG_OFFLINE_TOOL_MODE_
   /// Shuffle sample indices
   void shuffle_indices() override;
+  /**
+   * Compute the number of parallel readers based on the type of io_buffer,
+   * the mini batch size, the requested number of parallel readers.
+   * This is done before populating the sample indices.
+   */
+  int compute_max_num_parallel_readers();
+  /**
+   * Check if there are sufficient number of samples for the given number of
+   * data readers with distributed io buffer, based on the number of samples,
+   * the number of models and the mini batch size.
+   */
+  bool check_num_parallel_readers(long data_set_size);
   /// Determine the number of samples to use
   void determine_num_samples_to_use();
   /**

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -129,6 +129,13 @@ class data_reader_jag_conduit : public generic_data_reader {
   void select_subset_of_data() override;
   /// Replace the sample indices with the unused sample indices.
   void use_unused_index_set() override;
+  /// Set the type of io_buffer that will rely on this reader
+  void set_io_buffer_type(const std::string io_buffer);
+
+  /// Set the id of this local instance
+  void set_local_id() { m_local_reader_id = m_num_local_readers++; }
+  /// Get the id of this local instance
+  int get_local_id() const { return m_local_reader_id; }
 #else
   /// Load a data file
   void load_conduit(const std::string conduit_file_path, size_t& idx);
@@ -361,6 +368,17 @@ class data_reader_jag_conduit : public generic_data_reader {
    * This is the sum of m_local_num_samples_to_use.
    */
   size_t m_global_num_samples_to_use;
+
+  /**
+   * io_buffer type that will rely on this reader.
+   * e.g. distributed_io_buffer, partitioned_io_buffer
+   */
+  std::string m_io_buffer_type;
+
+  /// The number of local instances of this reader type
+  static int m_num_local_readers;
+  /// locally addressable id in case of multiple data reader instances attached to a model
+  int m_local_reader_id;
 };
 
 

--- a/include/lbann/io/data_buffers/distributed_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/distributed_io_buffer.hpp
@@ -132,6 +132,7 @@ class distributed_io_buffer : public generic_io_buffer {
   void calculate_num_iterations_per_epoch_spanning_models(int max_mini_batch_size, generic_data_reader *data_reader) override;
   void calculate_num_iterations_per_epoch_single_model(int max_mini_batch_size, generic_data_reader *data_reader) override;
   int compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers) const override;
+  static int compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers, const lbann_comm* comm);
 
   data_buffer *get_data_buffer(const execution_mode mode) const {
     data_buffer *data_buffer = nullptr;

--- a/include/lbann/io/data_buffers/distributed_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/distributed_io_buffer.hpp
@@ -133,6 +133,7 @@ class distributed_io_buffer : public generic_io_buffer {
   void calculate_num_iterations_per_epoch_single_model(int max_mini_batch_size, generic_data_reader *data_reader) override;
   int compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers) const override;
   static int compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers, const lbann_comm* comm);
+  static bool check_num_parallel_readers(long data_set_size, int mini_batch_size, int num_parallel_readers, const lbann_comm* comm);
 
   data_buffer *get_data_buffer(const execution_mode mode) const {
     data_buffer *data_buffer = nullptr;

--- a/include/lbann/io/data_buffers/partitioned_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/partitioned_io_buffer.hpp
@@ -58,6 +58,7 @@ class partitioned_io_buffer : public generic_io_buffer {
   void calculate_num_iterations_per_epoch_spanning_models(int max_mini_batch_size, generic_data_reader *data_reader) override;
   void calculate_num_iterations_per_epoch_single_model(int max_mini_batch_size, generic_data_reader *data_reader) override;
   int compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers) const override;
+  static int compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers, const lbann_comm* comm);
 
   std::vector<CPUMat*> M_local;
 };

--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -17,7 +17,7 @@ void init_data_readers(
   std::map<execution_mode, lbann::generic_data_reader *>& data_readers);
 
 /// adjusts the number of parallel data readers
-void set_num_parallel_readers(lbann::lbann_comm *comm, lbann_data::LbannPB& p);
+void set_num_parallel_readers(const lbann::lbann_comm *comm, lbann_data::LbannPB& p);
 
 /// adjusts the values in p by querying the options db
 void get_cmdline_overrides(lbann::lbann_comm *comm, lbann_data::LbannPB& p);

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -69,6 +69,8 @@
 
 namespace lbann {
 
+int data_reader_jag_conduit::m_num_local_readers = 0;
+
 const std::set<std::string> data_reader_jag_conduit::non_numeric_vars = {
   "fusion_reaction",
   "fusion_model_reaction",
@@ -186,6 +188,10 @@ void data_reader_jag_conduit::use_unused_index_set() {
   m_unused_samples.shrink_to_fit();
   adjust_num_samples_to_use();
 }
+
+void data_reader_jag_conduit::set_io_buffer_type(const std::string io_buffer) {
+  m_io_buffer_type = io_buffer;
+}
 #endif // _JAG_OFFLINE_TOOL_MODE_
 
 data_reader_jag_conduit::data_reader_jag_conduit(const std::shared_ptr<cv_process>& pp, bool shuffle)
@@ -230,6 +236,8 @@ void data_reader_jag_conduit::copy_members(const data_reader_jag_conduit& rhs) {
   m_unused_samples = rhs.m_unused_samples;
   m_local_num_samples_to_use = rhs.m_local_num_samples_to_use;
   m_global_num_samples_to_use = rhs.m_global_num_samples_to_use;
+  m_io_buffer_type = rhs.m_io_buffer_type;
+  m_local_reader_id = rhs.m_local_reader_id;
 }
 
 data_reader_jag_conduit::data_reader_jag_conduit(const data_reader_jag_conduit& rhs)
@@ -275,6 +283,8 @@ void data_reader_jag_conduit::set_defaults() {
   m_valid_samples.clear();
   m_local_num_samples_to_use = 0ul;
   m_global_num_samples_to_use = 0ul;
+  m_io_buffer_type = "";
+  m_local_reader_id = 0;
 }
 
 /// Replicate image processor for each OpenMP thread

--- a/src/io/data_buffers/distributed_io_buffer.cpp
+++ b/src/io/data_buffers/distributed_io_buffer.cpp
@@ -192,7 +192,7 @@ int lbann::distributed_io_buffer::compute_max_num_parallel_readers(long data_set
   /// Check to make sure that there is enough data for all of the parallel readers
   if(data_set_size != 0) {
     int max_num_parallel_readers = num_parallel_readers;
-    while(ceil((float)data_set_size / (float)(mini_batch_size * comm->get_num_models())) < max_num_parallel_readers) {
+    while (!check_num_parallel_readers(data_set_size, mini_batch_size, max_num_parallel_readers, comm)) {
       max_num_parallel_readers--;
     }
     if(comm->am_world_master() && max_num_parallel_readers != num_parallel_readers) {
@@ -205,6 +205,10 @@ int lbann::distributed_io_buffer::compute_max_num_parallel_readers(long data_set
   } else {
     return 0;
   }
+}
+
+bool lbann::distributed_io_buffer::check_num_parallel_readers(long data_set_size, int mini_batch_size, int num_parallel_readers, const lbann_comm* comm) {
+  return !(ceil((float)data_set_size / (float)(mini_batch_size * comm->get_num_models())) < num_parallel_readers);
 }
 
 void lbann::distributed_io_buffer::calculate_num_iterations_per_epoch(int num_models, int model_rank, int max_mini_batch_size, generic_data_reader *data_reader) {

--- a/src/io/data_buffers/partitioned_io_buffer.cpp
+++ b/src/io/data_buffers/partitioned_io_buffer.cpp
@@ -84,22 +84,26 @@ bool lbann::partitioned_io_buffer::is_data_set_processed(generic_data_reader *da
 }
 
 int lbann::partitioned_io_buffer::compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers) const {
+  return partitioned_io_buffer::compute_max_num_parallel_readers(data_set_size, mini_batch_size, requested_num_parallel_readers, m_comm);
+}
+
+int lbann::partitioned_io_buffer::compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers, const lbann_comm* comm) {
   int num_parallel_readers = requested_num_parallel_readers;
 
-  if(m_comm->get_procs_per_model() != num_parallel_readers) {
-    if (m_comm->am_model_master()) {
+  if(comm->get_procs_per_model() != num_parallel_readers) {
+    if (comm->am_model_master()) {
       std::cout << "Warning the requested number of parallel readers "
                 << num_parallel_readers
                 << " does not match the grid size "
-                << m_comm->get_procs_per_model()
+                << comm->get_procs_per_model()
                 << " OVERRIDING requested number of parallel readers."
                 << std::endl;
     }
-    num_parallel_readers = m_comm->get_procs_per_model();
+    num_parallel_readers = comm->get_procs_per_model();
   }
 
   if(mini_batch_size < num_parallel_readers) {
-    if (m_comm->am_model_master()) {
+    if (comm->am_model_master()) {
       std::cout << "Warning the requested number of parallel readers "
                 << num_parallel_readers
                 << " is larger than the requested mini-batch size "


### PR DESCRIPTION
Expose some of computations in io buffers that are relevant to compute the number of parallel readers as static interfaces. This enables data reader to consistently compute the number of parallel readers even before instantiating io buffers.

data reader instances can use this information to divide the set of input data files among data reader instances, which has to occur before instantiating io buffers.

The approach here for each data reader rank to use a unique set of data files is
to populate `m_shuffled_indices` such that each data reader rank will see an ordered sequence 1, 2, 3, 4, ....., which are the indices to its own local sample buffer. Then, I shuffle the local sample buffer instead of `m_shuffled_indices`.
For example, if I have the mini batch of size 4 and 2 parallel readers,
with `partition_io_buffers`, `m_shuffled_indices` contains 1122334455667788 ....
On the other hand, with `distributed_io_buffers`, `m_shuffled_indices` contains 1234123456785678....